### PR TITLE
Update to 0.9.15

### DIFF
--- a/rpm/0001-CMake-require-at-least-CMake-3.5.patch
+++ b/rpm/0001-CMake-require-at-least-CMake-3.5.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
+Date: Tue, 13 May 2025 08:37:07 +0300
+Subject: [PATCH] CMake: require at least CMake 3.5
+
+CMake 4 dropped support for version requirements < 3.5.
+
+Fixes building with CMake >= 4.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 205f3928035cb4efc0f771d8a6e873cf9a4ef12a..9b8118c81837360df1cc151a9583c8b5a5fa64c6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ set(PROJECT_LANGUAGES C)
+ 

--- a/rpm/libvncserver.spec
+++ b/rpm/libvncserver.spec
@@ -1,10 +1,11 @@
 # Note that this is NOT a relocatable package
 Name:           libvncserver
-Version:        0.9.14
+Version:        0.9.15
 Release:        1
 License:        GPLv2+ and MIT and BSD-2-Clause
 URL:            https://github.com/mer-qa/libvncserver
 Source:         %{name}-%{version}.tar.gz
+Patch1:         0001-CMake-require-at-least-CMake-3.5.patch
 BuildRequires:  libjpeg-turbo-devel
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libpng)
@@ -33,31 +34,21 @@ Requires:     %{name} = %{version}
 Header Files for %{name}.
 
 %prep
-%setup -q -n %{name}-%{version}/libvncserver
+%autosetup -p1 -n %{name}-%{version}/libvncserver
 
 %build
-%cmake .
+%cmake
 %cmake_build
 
 %install
 %cmake_install
 
-%clean
-[ -n "%{buildroot}" -a "%{buildroot}" != / ] && rm -rf %{buildroot}
-
-%pre
-%post
-%preun
-%postun
-
 %files
-%defattr(-,root,root)
 %doc README.md AUTHORS ChangeLog NEWS.md
 %{_libdir}/libvncclient.so*
 %{_libdir}/libvncserver.so*
 
 %files devel
-%defattr(-,root,root)
 %{_includedir}/rfb/*
 %{_libdir}/pkgconfig/libvncclient.pc
 %{_libdir}/pkgconfig/libvncserver.pc


### PR DESCRIPTION
Backport patch to fix build with cmake 4.
Remove not needed defattr from spec. Cleanup spec.